### PR TITLE
incorporacao da exception when others

### DIFF
--- a/prc_afunda_barco.sql
+++ b/prc_afunda_barco.sql
@@ -17,4 +17,7 @@ BEGIN
          v_vl_tot_item := 00;
   
   end loop;  
+EXCEPTION
+	WHEN OTHERS THEN
+		raise_application_error( -20003, SQLErrM);		
 END PRC_AFUNDA_BARCO;


### PR DESCRIPTION
Nessa fase da entrega foi necessario incluir um when others para facilitar as mensagens  de exceção.
